### PR TITLE
Fix bug related to classname and case sensitivity

### DIFF
--- a/src/Modules/Module.php
+++ b/src/Modules/Module.php
@@ -254,7 +254,7 @@ abstract class Module implements \Webleit\ZohoBooksApi\Contracts\Module
     public function getModelClassName()
     {
         $className = (new \ReflectionClass($this))->getShortName();
-        $class = '\\Webleit\\ZohoBooksApi\\Models\\' . Inflector::singularize(Inflector::camelize($className));
+        $class = '\\Webleit\\ZohoBooksApi\\Models\\' . ucfirst(strtolower(Inflector::singularize($className)));
 
         return $class;
     }


### PR DESCRIPTION
getModelClassName is returning the class name in camelCase. This cause problem for the autoloader on case sensitive file system.