### PR TITLE
Fixes #22 - Send the data via the actual post

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -190,7 +190,8 @@ class Client
         return $this->processResult($this->httpClient->post(
             $url,
             $this->getOptions([
-                'query' => $this->getParams($organizationId, $data) + $params,
+                'query' => $this->getParams($organizationId) + $params,
+                'form_params' => [ 'JSONString' => json_encode($data) ]
             ])
         ));
     }


### PR DESCRIPTION
This sends the post data as part of the actual post. Previously,
it was adding everything onto the request, which causes Zoho to
send a '414 Request-URI too large'.

See http://docs.guzzlephp.org/en/stable/request-options.html#form-params
