### PR TITLE
Allow apinames to differ from requests

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -132,9 +132,8 @@ abstract class Model implements \JsonSerializable, Arrayable
     {
         if (method_exists($this->module, 'getApiKeyName')) {
             return $this->module->getApiKeyName();
-        } else {
-            return strtolower($this->getName() . '_id');
         }
+        return strtolower($this->getName() . '_id');
     }
 
     /**

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Webleit\ZohoBooksApi\Models;
 
 use Doctrine\Common\Inflector\Inflector;
@@ -129,7 +130,11 @@ abstract class Model implements \JsonSerializable, Arrayable
      */
     public function getKeyName()
     {
-        return strtolower($this->getName() . '_id');
+        if (method_exists($this->module, 'getApiKeyName')) {
+            return $this->module->getApiKeyName();
+        } else {
+            return strtolower($this->getName() . '_id');
+        }
     }
 
     /**

--- a/src/Modules/Module.php
+++ b/src/Modules/Module.php
@@ -41,7 +41,7 @@ abstract class Module implements \Webleit\ZohoBooksApi\Contracts\Module
         $list = $this->client->getList($this->getUrl(), null, $params);
 
         $collection = new Collection($list[$this->getResourceKey()]);
-        $collection = $collection->mapWithKeys(function($item) {
+        $collection = $collection->mapWithKeys(function ($item) {
             $item = $this->make($item);
             return [$item->getId() => $item];
         });
@@ -157,7 +157,11 @@ abstract class Module implements \Webleit\ZohoBooksApi\Contracts\Module
      */
     protected function getResourceKey()
     {
-        return strtolower($this->getName());
+        if (method_exists($this, 'getApiName')) {
+            return $this->getApiName();
+        } else {
+            return strtolower($this->getName());
+        }
     }
 
     /**

--- a/src/Modules/Module.php
+++ b/src/Modules/Module.php
@@ -153,15 +153,18 @@ abstract class Module implements \Webleit\ZohoBooksApi\Contracts\Module
     }
 
     /**
+     * This is used to determine the key of the returned data
+     *
+     * Note that some modules (eg, Settings\TaxExemptions) override
+     * this value, because zoho does not return the data with the
+     * expected key. If you are looking at this code, you may also
+     * need to override the api key name, too.
+     *
      * @return string
      */
-    protected function getResourceKey()
+    public function getResourceKey()
     {
-        if (method_exists($this, 'getApiName')) {
-            return $this->getApiName();
-        } else {
-            return strtolower($this->getName());
-        }
+        return strtolower($this->getName());
     }
 
     /**

--- a/src/Modules/Settings/TaxExemptions.php
+++ b/src/Modules/Settings/TaxExemptions.php
@@ -28,7 +28,7 @@ class TaxExemptions extends Module
 
     /**
      * Return Zoho API name
-     * 
+     *
      * Note that this is different from the request. The request
      * is for 'taxexemptions', but it returns an array with a key
      * of "tax_exemptions"
@@ -36,5 +36,17 @@ class TaxExemptions extends Module
     public function getApiName()
     {
         return "tax_exemptions";
+    }
+
+    /**
+     * Return Zoho API Key Name
+     *
+     * This is the unique key used to return data. With the taxexcemptions
+     * module, it returns the data as an array in 'tax_exceptions' but the
+     * actual key is 'tax_exception_id', without the trailing s.
+     */
+    public function getApiKeyName()
+    {
+        return "tax_exemption_id";
     }
 }

--- a/src/Modules/Settings/TaxExemptions.php
+++ b/src/Modules/Settings/TaxExemptions.php
@@ -29,11 +29,11 @@ class TaxExemptions extends Module
     /**
      * Return Zoho API name
      *
-     * Note that this is different from the request. The request
-     * is for 'taxexemptions', but it returns an array with a key
-     * of "tax_exemptions"
+     * This overrides getResourceKey in Module, which normally
+     * returns strtolower of name. However, Zoho returns "tax_exemptions"
+     * instead of the expected 'taxexceptions' key.
      */
-    public function getApiName()
+    public function getResourceKey()
     {
         return "tax_exemptions";
     }

--- a/src/Modules/Settings/TaxExemptions.php
+++ b/src/Modules/Settings/TaxExemptions.php
@@ -25,4 +25,16 @@ class TaxExemptions extends Module
     {
         return '\\Webleit\\ZohoBooksApi\\Models\\Settings\\TaxExemption';
     }
+
+    /**
+     * Return Zoho API name
+     * 
+     * Note that this is different from the request. The request
+     * is for 'taxexemptions', but it returns an array with a key
+     * of "tax_exemptions"
+     */
+    public function getApiName()
+    {
+        return "tax_exemptions";
+    }
 }


### PR DESCRIPTION
This allows a model to have an apiname that is different to
the request name, because Zoho.

This came about when I tried to request taxexemptions from zoho,
and it returns an array with the key 'tax_exemptions'. I'm sure
there'll be others, but this is the first one I've found so far.