### PR TITLE
Fixes #33 - Zoho's documentation is wrong.

### DIFF
--- a/src/Modules/Module.php
+++ b/src/Modules/Module.php
@@ -187,6 +187,13 @@ abstract class Module implements \Webleit\ZohoBooksApi\Contracts\Module
     }
 
     /**
+     * Mark something with a status
+     *
+     * Note that as of 2019-11-27, Zoho Books API errors if you don't
+     * provide a JSONString param. It can't be empty.
+     *
+     * See https://github.com/Weble/ZohoBooksApi/issues/33
+     *
      * @param $id
      * @param $status
      * @param string $key
@@ -194,7 +201,11 @@ abstract class Module implements \Webleit\ZohoBooksApi\Contracts\Module
      */
     public function markAs($id, $status, $key = 'status')
     {
-        $this->client->post($this->getUrl() . '/' . $id . '/' . $key . '/' . $status);
+        $this->client->post(
+            $this->getUrl() . '/' . $id . '/' . $key . '/' . $status,
+            null,
+            ["random" => "data"]
+        );
         // If we arrive here without exceptions, everything went well
         return true;
     }


### PR DESCRIPTION
When trying to void a credit note, the Books API was crashing
saying that it needed a JSONString param. At a guess, there's
some checks in their backend for a POST, and it must contain
JSONData before it gets processed.

THIS IS WHY REST EXISTS, ZOHO. YOU SHOULD BE USING A PATCH, NOT
A POST CALL.