### PR TITLE
Zohos API documentation is incorrect for adding credit notes

### DIFF
--- a/src/Modules/CreditNotes.php
+++ b/src/Modules/CreditNotes.php
@@ -37,7 +37,7 @@ class CreditNotes extends Documents
      */
     public function applyToInvoices($id, $data)
     {
-	throw new \Exception("This does not work, and the documentation is wrong. Use invoices->applyCreditNote()");
+        throw new \Exception("This does not work, and the documentation is wrong. Use invoices->applyCreditNote()");
         $data = $this->client->post($this->getUrl() . '/' . $id . '/invoices', null, $data);
 
         return $data['apply_to_invoices']['invoices'];

--- a/src/Modules/CreditNotes.php
+++ b/src/Modules/CreditNotes.php
@@ -37,7 +37,8 @@ class CreditNotes extends Documents
      */
     public function applyToInvoices($id, $data)
     {
-        $data = $this->client->post($this->getUrl() . '/' . $id . '/invoices', $data);
+	throw new \Exception("This does not work, and the documentation is wrong. Use invoices->applyCreditNote()");
+        $data = $this->client->post($this->getUrl() . '/' . $id . '/invoices', null, $data);
 
         return $data['apply_to_invoices']['invoices'];
     }

--- a/src/Modules/Invoices.php
+++ b/src/Modules/Invoices.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Webleit\ZohoBooksApi\Modules;
+
 use Webleit\ZohoBooksApi\Modules\Mixins\Creditable;
 use Webleit\ZohoBooksApi\Modules\Mixins\Payable;
 
@@ -95,7 +96,6 @@ class Invoices extends Documents
         return $this->doAction($id, 'writeoff/cancel');
     }
 
-
     /**
      * @param $id string
      * @return boolean
@@ -103,5 +103,27 @@ class Invoices extends Documents
     public function markAsDraft($id)
     {
         return $this->markAs($id, 'draft');
+    }
+
+    /**
+     * Apply a credit note to an invoice.
+     *
+     * Note that is is NOT DOCUMENTED in their API, and the way they say
+     * to do it does not work. I had to reverse engineer this by looking at
+     * what the React web client uses in the developer console.
+     *
+     * @param string $invid Invoice ID
+     * @param string $creditid Credit Note ID
+     * @param float $amount Amount of credit note to apply.
+     */
+    public function applyCreditNote($invid, $creditid, $amount)
+    {
+        $data = ['apply_creditnotes' => [
+            ["creditnote_id" => $creditid, "amount_applied" => $amount]
+        ]];
+
+        $this->client->post($this->getUrl() . '/' . $invid . '/credits', null, $data);
+        // If we arrive here without exceptions, everything went well
+        return true;
     }
 }


### PR DESCRIPTION
This is how their React UI does it.

POST: https://i.imgur.com/YrET3dz.png

    JSONString:
      {"apply_creditnotes":[{"creditnote_id":"2094563000000099301","amount_applied":"5.00"}]}
    organization_id: 701433241

Response: https://i.imgur.com/55NAgtF.png

    code: 0
    message: "Credits have been applied to the invoice(s)."
    use_credits: {
      apply_creditnotes:
        0:
          amount_applied: 5
          creditnote_id: "2094563000000099301"
          creditnotes_invoice_id: "2094563000000101019"
          date: "2019-11-28"
          date_formatted: "November 28, 2019"
          invoice_id: "2094563000000097007"
      invoice_payments: []