### PR TITLE
Use singular resource item key when returning data from the update() method

### DIFF
--- a/src/Modules/Module.php
+++ b/src/Modules/Module.php
@@ -107,7 +107,7 @@ abstract class Module implements \Webleit\ZohoBooksApi\Contracts\Module
     public function update($id, $data, $params = [])
     {
         $data = $this->client->put($this->getUrl(), $id, $data, $params);
-        $data = $data[$this->inflector->pluralize($this->getResourceItemKey())];
+        $data = $data[$this->inflector->singularize($this->getResourceItemKey())];
 
         return $this->make($data);
     }


### PR DESCRIPTION
Seems this was a regression introduced in commit  2d223c6