### PR TITLE
get exchange rate of a currency not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ $total = $invoice->total;
 
 will return a \Webleit\ZohoBooksApi\Models\Invoice object, which is Arrayable and Jsonable, and that can be therefore used in many ways.
 
+## Zoho Books token expiration notes
+* Each access token is valid for only an hour and used only for the operations defined in the scope.
+* Refresh token does not expire. Use it to refresh access tokens when they expire.
+* You can only generate a maximum of five refresh tokens in a minute.
+
 ## Contributing
 
 Finding bugs, sending pull requests or improving the docs - any contribution is welcome and highly appreciated

--- a/src/Modules/RecurringInvoices.php
+++ b/src/Modules/RecurringInvoices.php
@@ -38,4 +38,17 @@ class RecurringInvoices extends Documents
     {
         return 'recurring_invoices';
     }
+
+    /**
+     * Override returned API key name
+     *
+     * This overrides the API key name that is returned from zoho, as they
+     * send back 'recurring_invoice_id' instead of 'recurringinvoices_id'
+     *
+     * @return string
+     */
+    public function getApiKeyName()
+    {
+        return 'recurring_invoice_id';
+    }
 }


### PR DESCRIPTION

Getting currency is not working.
$ExchangeRates = $zohoBooks->settings->currencies->getExchangeRates('28245000000000059');


If I use postman it works.
![Postman_7cAjg2e4ti](https://user-images.githubusercontent.com/8874242/111899720-3820dc00-8a26-11eb-906f-4625466fa7fa.png)

Here is the example of how I'm calling it, I receive a lot of data but unable to get what I want.
![tZAcWacstj](https://user-images.githubusercontent.com/8874242/111899740-47078e80-8a26-11eb-9025-70a9c249ad3c.gif)
