### PR TITLE
Utilize __isset in base Model.php

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -61,6 +61,14 @@ abstract class Model implements \JsonSerializable, Arrayable
     {
         $this->data[$name] = $value;
     }
+    
+    /**
+     * @param $name
+     */
+    function __isset($name)
+    {
+        return isset($this->data[$name]);
+    }
 
     /**
      * @param $name


### PR DESCRIPTION
The base model needs `__isset` because `__get` references `$this->data`.

Example of issue:
```
empty($invoice->due_date) //true
```
```
$due_date = $invoice->due_date;
empty($due_date) //false
```
This might be a breaking change for some because it would change the functionality of isset against the base Model but it makes it work more sanely 