### PR TITLE
Fixes PHP 8.0 ErrorException

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -27,7 +27,7 @@ abstract class Model implements \JsonSerializable, Arrayable
      * @param array $data
      * @param  Module   $module
      */
-    public function __construct($data = [], Module $module)
+    public function __construct(array $data, Module $module)
     {
         $this->data = $data;
         $this->module = $module;


### PR DESCRIPTION
This fixes PHP 8.0 `ErrorException: Required parameter $module follows optional parameter $data`