### PR TITLE
Null coalesce $data to be array if it was null

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -24,12 +24,12 @@ abstract class Model implements \JsonSerializable, Arrayable
 
     /**
      * Model constructor.
-     * @param array $data
+     * @param mixed $data
      * @param  Module   $module
      */
-    public function __construct(array $data, Module $module)
+    public function __construct($data, Module $module)
     {
-        $this->data = $data;
+        $this->data = $data ?? [];
         $this->module = $module;
         $this->inflector = InflectorFactory::create()->build();
     }


### PR DESCRIPTION
This allows functionality as it was previously without defining a default to `$data` so it makes #79 more of a non-breaking change which is what @Skullbock intended