### PR TITLE
Remove copied content from Contact, add ApiKeyName

### DIFF
--- a/src/Modules/ChartOfAccounts.php
+++ b/src/Modules/ChartOfAccounts.php
@@ -2,7 +2,6 @@
 
 namespace Webleit\ZohoBooksApi\Modules;
 use Webleit\ZohoBooksApi\Client;
-use Webleit\ZohoBooksApi\Modules\Contacts\ContactPersons;
 
 /**
  * Class ChartOfAccounts
@@ -10,28 +9,15 @@ use Webleit\ZohoBooksApi\Modules\Contacts\ContactPersons;
  */
 class ChartOfAccounts extends Module
 {
-    /**
-     * @var ContactPersons
-     */
-    public $contactpersons;
-
-    public function __construct(Client $client)
-    {
-        parent::__construct($client);
-
-        $this->contactpersons = new ContactPersons($client);
-    }
 
     /**
-     * @param $id
-     * @return \Illuminate\Support\Collection
+     * Return Zoho API Key Name for Chart of Accounts
      */
-    public function getContactPersons($id)
+    public function getApiKeyName()
     {
-        $className = $this->getModelClassName() . '\\Person';
-        return $this->getPropertyList('contactpersons', $id, $className, 'contact_persons', $this->contactpersons);
+        return 'account_id';
     }
-
+    
     /**
      * @param $id
      * @return bool


### PR DESCRIPTION
Hi, updating the chart of accounts module, which currently looks like it was copied from the Contact Persons module.
Removed the contact person methods.
Added the API key name for accounts_id