### PR TITLE
Fix `ContactPersons::markAsPrimary()` adding random data to avoid a Zoho API REST error when "JSONString" is empty

### DIFF
--- a/src/Modules/Contacts/ContactPersons.php
+++ b/src/Modules/Contacts/ContactPersons.php
@@ -32,14 +32,19 @@ class ContactPersons extends Module
     }
 
     /**
+     * Note that as of 2019-11-27, Zoho Books API errors if you don't
+     * provide a JSONString param. It can't be empty.
+     *
+     * See https://github.com/Weble/ZohoBooksApi/issues/33
+     *
      * @param $id string
      * @return boolean
      */
     public function markAsPrimary($id)
     {
-        $this->client->post($this->getUrl() . '/' . $id . '/primary');
+        $this->client->post($this->getUrl() . '/' . $id . '/primary', ["random" => "data"]);
 
-        // If we arrive here without exceptions, everything went well
+        // If we arrive here without exceptions, everything went well.
         return true;
     }
 }


### PR DESCRIPTION
I copy the solution applied to `Module::markAs()` at https://github.com/Weble/ZohoBooksApi/commit/a09677ed3c4a39fd1ae23df4aa556ee6b74b2184. The same problem occurs with `ContactPersons::markAsPrimary()`.

Fixes #33. 


