### PR TITLE
Update PreferenceModule with new Zoho Finance app domain

### DIFF
--- a/src/Modules/PreferenceModule.php
+++ b/src/Modules/PreferenceModule.php
@@ -16,7 +16,7 @@ abstract class PreferenceModule implements \Webleit\ZohoBooksApi\Contracts\Modul
      * Base Url of the Zoho Books Api
      * @var string
      */
-    const ENDPOINT = 'https://books.zoho.com/api/v3/';
+    const ENDPOINT = 'https://www.zohoapis.com/books/v3/';
 
     /**
      * @var Client


### PR DESCRIPTION
In https://github.com/Weble/ZohoBooksApi/pull/113 all the domains in Client.php are updated but [src/Modules/PreferenceModule.php](https://github.com/Weble/ZohoBooksApi/blob/develop/src/Modules/PreferenceModule.php) was missing.

https://help.zoho.com/portal/en/community/topic/update-regarding-zoho-finance-applications-domain-for-api-users-2-2-2024