### PR TITLE
Update Client.php

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -81,7 +81,7 @@ class Client
      */
     protected $rateLimitRemaining;
 
-    public function __construct(OAuthClient $oAuthClient, ClientInterface $client = null)
+    public function __construct(OAuthClient $oAuthClient, ?ClientInterface $client = null)
     {
         if (!$client) {
             $client = new \GuzzleHttp\Client();


### PR DESCRIPTION
Fixes PHP Deprecated:  Webleit\ZohoBooksApi\Client::__construct(): Implicitly marking parameter $client as nullable is deprecated, the explicit nullable type must be used instead